### PR TITLE
Add hotfix for windows text display encoding.

### DIFF
--- a/src/uCtrlDesktop/main.cpp
+++ b/src/uCtrlDesktop/main.cpp
@@ -32,6 +32,8 @@ void SaveSystemToFile(USystem* s, std::string filename)
 
 void LoadSystemFromFile(USystem* s, std::string filename)
 {
+    QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
+
     QFile f(QString::fromStdString(filename));
     if (f.open(QFile::ReadOnly | QFile::Text)){
         QTextStream in(&f);


### PR DESCRIPTION
Windows encoding hotfix.

Need test on Windows and Linux if it broke something.
